### PR TITLE
Faster queries

### DIFF
--- a/ICSDClient.py
+++ b/ICSDClient.py
@@ -429,21 +429,58 @@ class ICSDClient:
                 raise Exception('Failed to get cifs.')
 
 
-def main():
-    def fetch_all_cifs(self, auth_token, cif_path="./cifs/"):
-        max_coll_code = 1_000_000
-        with ICSDHelper() as cli:
-            search_string = f"collectioncode=0-{max_coll_code}"
-            ids = cli.search(search_string)
-            cli.cifs_to_zip(ids, 'test_search')
 
-    def test(cli):
-        search_string = "numberofelements: 1 and composition: Fe"
+# examples
+def test(cli: ICSDHelper):
+    search_string = "numberofelements: 1 and composition: Fe"
+    ids = cli.search(search_string)
+    print(len(ids))
+    cli.data_to_csv(ids)
+    cli.cifs_to_zip(ids, 'test_search')
+
+def fetch_all_cifs():
+    max_coll_code = 1_000_000
+    search_string = f"collectioncode=0-{max_coll_code}"
+    with ICSDHelper() as cli:
         ids = cli.search(search_string)
-        print(len(ids))
-        cli.data_to_csv(ids)
         cli.cifs_to_zip(ids, 'test_search')
 
+def intermetallics(cli: ICSDHelper):
+    non_metals = {'H', 'D', 'T', 'He', 
+        'B', 'C', 'N', 'O', 'F', 'Ne', 
+        'Si', 'P', 'S', 'Cl', 'Ar', 
+        # 'Ge', 
+        'As', 'Se', 'Br', 'Kr',
+        # 'Sb',
+        'Te', 'I', 'Xe',
+        # 'Po',
+        'At', 'Rn',
+        'Ts', 'Og'}
+    
+    include_nm = ' or '.join([f'composition: {el}' for el in non_metals])
+    exclude_nm = 'not (' + include_nm + ')'
+    search_string = 'numberofelements: >=2 ' + exclude_nm
+    
+    ids = cli.search(search_string)
+    cli.data_to_csv(
+        ids, 
+        'intermetallics_data',
+        columns = ['StructuredFormula', 'ChemicalName'])
+    cli.cifs_to_zip(ids, 'intermetallics_search')
+
+def minerals(cli: ICSDHelper):
+    search_string = "mineralname: *"
+    search_string = 'numberofelements: >=2 and ' + search_string
+    
+    ids = cli.search(search_string)
+    cli.data_to_csv(
+        ids, 
+        'minerals_data2', 
+        columns = ['StructuredFormula', 'ChemicalName', 'MineralName', 'MineralGroup'])
+    cli.cifs_to_zip(ids, 'minerals_search2')
+
+
+def main():
     with ICSDHelper("YOUR USERNAME", "YOUR PASSWORD", verbose=True) as cli:
         test(cli)   
 

--- a/ICSDClient.py
+++ b/ICSDClient.py
@@ -3,6 +3,9 @@ import re
 import numpy as np 
 import datetime
 import pandas as pd 
+from contextlib import contextmanager
+from functools import partial
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import requests 
 from bs4 import BeautifulSoup
@@ -42,116 +45,40 @@ def main():
 
     client.logout()
 
-class ICSDClient():
-    def __init__(self, login_id=None, password=None, windows_client=False, timeout=15):
-        self.auth_token = None 
-        self.session_history = []
-        self.windows_client = windows_client
+class ICSDHelper:
+    MAX_CIFS = 500
+
+    def __init__(self, id, pwd, verbose=False):
+        self.id = id
+        self.pwd = pwd
+        self.query_mgr = ICSDClient()
+        self.token = None
+        self.verbose = verbose
         self.search_dict = self.load_search_dict()
-        self.timeout = timeout
 
-        if login_id is not None:
-            self.login_id = login_id
-            self.password = password
-            self.authorize()
+    def connect(self):        
+        self.token = self.query_mgr.authorize(self.id, self.pwd)
+    
+    def close_connection(self):
+        self.query_mgr.logout(self.token)
+        self.token = None
 
-    def __del__(self):
-        self.logout()
+    @contextmanager
+    def temp_connection(self):
+        try:
+            token = self.query_mgr.authorize(self.id, self.pwd)
+            yield token
+        finally:
+            self.query_mgr.logout(token)
 
-    def authorize(self, verbose=True):
-        data = {"loginid": self.login_id,
-                "password": self.password}
+    def __enter__(self):
+        self.connect()
+        return self
 
-        headers = {
-            'accept': 'text/plain',
-            'Content-Type': 'application/x-www-form-urlencoded',
-        }
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.close_connection()
 
-        response = requests.post('https://icsd.fiz-karlsruhe.de/ws/auth/login', 
-                                 headers=headers, 
-                                 data=data)
-
-        if response.status_code == 200:
-            self.auth_token = response.headers['ICSD-Auth-Token']
-            if verbose: print(f"Authentication succeeded. Your Auth Token for this session is {self.auth_token} which will expire in one hour. Please remember to call client.logout() when you have finished.")
-        else:
-            if verbose: print(response.content)
-        
-        self.session_history.append(response)
-
-        return response
-
-    def logout(self, verbose=True):
-        headers = {
-            'accept': 'text/plain',
-            'ICSD-Auth-Token': self.auth_token,
-        }
-
-        response = requests.get('https://icsd.fiz-karlsruhe.de/ws/auth/logout', headers=headers)
-        if verbose: print(response.content)
-
-        self.session_history.append(response)
-
-        return response
-
-    def writeout(self, cifs, folder="./cifs/"):
-        if not os.path.exists(folder):
-            os.makedirs(folder)
-
-        if not isinstance(cifs, list):
-            if cifs is None:
-                print("Requires a valid cif string, this string is None. Ensure download was successful")
-                return 
-                
-            cifs = [cifs]
-        
-        for cif in cifs:
-            icsd_code = re.search(r"_database_code_ICSD ([0-9]+)", cif).group(1)
-            filename = f"icsd_{int(icsd_code):06}.cif"
-
-            with open(os.path.join(folder, filename), "w") as f:
-                for line in cif.splitlines():
-                    f.write(line + "\n")
-
-    def search(self, searchTerm, content_type=None):
-        '''
-        Available content EXPERIMENTAL_INORGANIC, EXPERIMENTAL_METALORGANIC, THERORETICAL_STRUCTURES
-        '''
-        if self.auth_token is None:
-            print("You are not authenticated, call client.authorize() first")
-            return 
-
-        if content_type is None:
-            params = (
-                ('query', searchTerm),
-                ('content type', "EXPERIMENTAL_INORGANIC"),
-            )
-
-        else: 
-            params = (
-                ('query', searchTerm),
-                ('content type', content_type),
-            )
-
-        headers = {
-            'accept': 'application/xml',
-            'ICSD-Auth-Token': self.auth_token,
-        }
-
-        response = requests.get('https://icsd.fiz-karlsruhe.de/ws/search/simple', 
-                                headers=headers, 
-                                params=params,
-                                timeout=self.timeout)
-
-        self.session_history.append({searchTerm: response})
-
-        search_results = [x for x in str(response.content).split("idnums")[1].split(" ")[1:-2]]
-        
-        compositions = self.fetch_data(search_results)
-        
-        return list(zip(search_results, compositions))
-
-    def advanced_search(self, search_dict, search_type="or",  property_list=["CollectionCode", "StructuredFormula"]):
+    def search(self, search_dict, search_type="and"):
         for k, v in search_dict.items():
             if k not in self.search_dict:
                 return f"Invalid search term {k} in search dict. Call client.search_dict.keys() to see available search terms"
@@ -161,171 +88,27 @@ class ICSDClient():
 
         search_string = f" {search_type} ".join([f"{str(k)} : {str(v)}" for k, v in search_dict.items()])
 
-        params = (
-            ('query', search_string),
-            ('content type', "EXPERIMENTAL_INORGANIC"),
-        )
-
-        headers = {
-            'accept': 'application/xml',
-            'ICSD-Auth-Token': self.auth_token,
-        }
-
-        response = requests.get('https://icsd.fiz-karlsruhe.de/ws/search/expert', 
-                                headers=headers, 
-                                params=params,
-                                timeout=self.timeout)
-
-        # TODO add exception handling for timeouts 
-
-        self.session_history.append({search_string: response})
-
-        soup = BeautifulSoup(response.content, features="xml")
-        search_results = soup.idnums.contents[0].split(" ")
-        # search_results = [x for x in str(response.content).split("idnums")[1].split(" ")[1:-2]]
-
-        properties = self.fetch_data(search_results, property_list=property_list)
-        
-        return list(zip(search_results, properties))
-
-    def fetch_data(self, ids, property_list=["CollectionCode", "StructuredFormula"]):
-        """
-        Available properties: CollectionCode, HMS, StructuredFormula, StructureType, 
-        Title, Authors, Reference, CellParameter, ReducedCellParameter, StandardizedCellParameter, 
-        CellVolume, FormulaUnitsPerCell, FormulaWeight, Temperature, Pressure, RValue, 
-        SumFormula, ANXFormula, ABFormula, ChemicalName, MineralName, MineralGroup, 
-        CalculatedDensity, MeasuredDensity, PearsonSymbol, WyckoffSequence, Journal, 
-        Volume, PublicationYear, Page, Quality
-        """
-        if len(ids) > 500:
-            chunked_ids = np.array_split(ids, np.ceil(len(ids)/500))
-
-            return_responses = []
-            for i, chunk in enumerate(chunked_ids):
-                return_responses.append(self.fetch_data(chunk, 
-                                                        property_list=property_list))
-                
-                if i % 2 == 0:
-                    self.logout(verbose=False)
-                    self.authorize(verbose=False)
-
-            flattened = [item for sublist in return_responses for item in sublist]
-
-            return flattened
-
-        headers = {
-            'accept': 'application/csv',
-            'ICSD-Auth-Token': self.auth_token,
-        }
-
-        params = (
-            ('idnum', ids),
-            ('windowsclient', self.windows_client),
-            ('listSelection', property_list),
-        )
-
-        response = requests.get('https://icsd.fiz-karlsruhe.de/ws/csv', headers=headers, params=params)
-
-        data = str(response.content).split("\\t\\n")[1:-1]
-
-        # If there's only a single response
-        if len(data) == 0 and len(ids) != 0:
-            data = str(response.content).split("\\t\\r\\n")[1:-1]
-
-        if len(property_list) > 1:
-            data = [x.split("\\t") for x in data]
-
-        self.session_history.append({str(ids): data})
-
-        return data
-
-    def fetch_cif(self, id):
-        if self.auth_token is None:
-            print("You are not authenticated, call client.authorize() first")
-            return 
-
-        headers = {
-            'accept': 'application/cif',
-            'ICSD-Auth-Token': self.auth_token,
-        }
-
-        params = (
-            ('celltype', 'experimental'),
-            ('windowsclient', self.windows_client),
-        )
-        
-        response = requests.get(f'https://icsd.fiz-karlsruhe.de/ws/cif/{id}', headers=headers, params=params)
-        
-        self.session_history.append({id: response})
-
-        return response.content.decode("UTF-8").strip()
+        return self.query_mgr.advanced_search(self.token, search_string)
 
     def fetch_cifs(self, ids):
-        if self.auth_token is None:
-            print("You are not authenticated, call client.authorize() first")
-            return 
+        def fetch_cif_batch(ids):            
+            with self.temp_connection() as auth_token:
+                return self.query_mgr.fetch_cifs(auth_token, ids)
+        
+        batched_ids = [ids[i: i + self.MAX_CIFS] for i in range(0, len(ids), self.MAX_CIFS)]
+        
+        if self.verbose: 
+            print(f'Fetching {len(ids)} cifs in {len(batched_ids)} batches.')
 
-        if isinstance(ids[0], tuple):
-            ids = [x[0] for x in ids]
-
-        if len(ids) > 500:
-            chunked_ids = np.array_split(ids, np.ceil(len(ids)/500))
-            return_responses = []
-
-            for i, chunk in enumerate(chunked_ids):
-                if i % 2 == 0:
-                    self.logout(verbose=False)
-                    self.authorize(verbose=False)
-
-                return_responses.append(self.fetch_cifs(chunk))
-                
-            flattened = [item for sublist in return_responses for item in sublist]
-
-            return_responses = ''.join(flattened)
-
-            cifs = re.split("\(C\) 2021 by FIZ Karlsruhe", return_responses)[1:]
-            cifs = [f'(C) {datetime.date.today().strftime("%Y")} by FIZ Karlsruhe' + x for x in cifs]
-            cifs = [x.encode("UTF-8") for x in cifs]
-
-            return cifs
-
-        headers = {
-            'accept': 'application/cif',
-            'ICSD-Auth-Token': self.auth_token,
-        }
-
-        params = (
-            ('idnum', ids),
-            ('celltype', 'experimental'),
-            ('windowsclient', self.windows_client),
-            ('filetype', 'cif'),
-        )
-
-        response = requests.get('https://icsd.fiz-karlsruhe.de/ws/cif/multiple', headers=headers, params=params)
-
-        cifs = re.split("\\(C\\) [0-9]{4} by FIZ Karlsruhe", response.content.decode("UTF-8"))[1:]
-        cifs = [f"(C) 2022 by FIZ Karlsruhe" + x for x in cifs]
-            
-        return cifs
-
-    def fetch_all_cifs(self, cif_path="./cifs/"):
-        for x in range(0, 1000000, 500):
-            self.logout(verbose=False)
-            self.authorize(verbose=False)
-
-            print(f"{x}-{x+499}")
-            search_res = self.advanced_search({"collectioncode": f"{x}-{x+499}"})
-
-            cifs = self.fetch_cifs(search_res)
-
-            try:
-                print(cifs[0])
-                print(cifs[-1])
-            except:
-                print("\n\nNO CIFS RETURNED, LAST RESPONSE:\n")
-                print(self.session_history[-1].content)
-                
-            self.writeout(cifs, cif_path)
+        with ThreadPoolExecutor(max_workers=8) as exec:
+            fut_to_ids = {exec.submit(fetch_cif_batch, batch): batch for i, batch in enumerate(batched_ids)}
+            for future in as_completed(fut_to_ids): 
+                ids = fut_to_ids[future]
+                try: 
+                    result = future.result()
+                    yield True, result
+                except Exception as e:
+                    yield False, ids 
 
     def load_search_dict(self):
         search_dict = {"AUTHORS" : None, # BIBLIOGRAPHY : Authors name for the main (first) reference Text
@@ -374,6 +157,256 @@ class ICSDClient():
                 "POLARAXIS" : None} #  SYMMETRY : Should polar axis be included TRUE or FALSE
 
         return {k.lower(): v for k, v in search_dict.items()}
+
+class ICSDClient:
+    STATUS_OK = 200
+
+    def __init__(self, windows_client=False, timeout=15):
+        self.session_history = []
+        self.windows_client = windows_client
+        self.timeout = timeout
+
+    def authorize(self, id, pwd, verbose=True):
+        data = {"loginid": id,
+                "password": pwd}
+
+        headers = {
+            'accept': 'text/plain',
+            'Content-Type': 'application/x-www-form-urlencoded',
+        }
+
+        response = requests.post('https://icsd.fiz-karlsruhe.de/ws/auth/login', 
+                                 headers=headers, 
+                                 data=data)
+        
+        self.session_history.append(response)
+
+        if response.status_code == self.STATUS_OK:
+            token = response.headers['ICSD-Auth-Token']
+            if verbose: print(f"Authentication succeeded. Your Auth Token for this session is {token} which will expire in one hour.")
+            return token
+        else:
+            if verbose: print(response.content)
+        
+    def logout(self, auth_token, verbose=True):
+        headers = {
+            'accept': 'text/plain',
+            'ICSD-Auth-Token': auth_token,
+        }
+
+        response = requests.get('https://icsd.fiz-karlsruhe.de/ws/auth/logout', headers=headers)
+        if verbose: print(response.content)
+
+        self.session_history.append(response)
+
+        return response
+
+    def writeout(self, cifs, folder="./cifs/"):
+        if not os.path.exists(folder):
+            os.makedirs(folder)
+
+        if not isinstance(cifs, list):
+            if cifs is None:
+                print("Requires a valid cif string, this string is None. Ensure download was successful")
+                return 
+                
+            cifs = [cifs]
+        
+        for cif in cifs:
+            icsd_code = re.search(r"_database_code_ICSD ([0-9]+)", cif).group(1)
+            filename = f"icsd_{int(icsd_code):06}.cif"
+
+            with open(os.path.join(folder, filename), "w") as f:
+                for line in cif.splitlines():
+                    f.write(line + "\n")
+
+    def search(self, auth_token, searchTerm, content_type=None):
+        '''
+        Available content EXPERIMENTAL_INORGANIC, EXPERIMENTAL_METALORGANIC, THERORETICAL_STRUCTURES
+        '''
+        if auth_token is None:
+            print("You are not authenticated, call client.authorize() first")
+            return 
+
+        if content_type is None:
+            params = (
+                ('query', searchTerm),
+                ('content type', "EXPERIMENTAL_INORGANIC"),
+            )
+
+        else: 
+            params = (
+                ('query', searchTerm),
+                ('content type', content_type),
+            )
+
+        headers = {
+            'accept': 'application/xml',
+            'ICSD-Auth-Token': auth_token,
+        }
+
+        response = requests.get('https://icsd.fiz-karlsruhe.de/ws/search/simple', 
+                                headers=headers, 
+                                params=params,
+                                timeout=self.timeout)
+
+        self.session_history.append({searchTerm: response})
+
+        search_results = [x for x in str(response.content).split("idnums")[1].split(" ")[1:-2]]
+        
+        compositions = self.fetch_data(search_results)
+        
+        return list(zip(search_results, compositions))
+
+    def advanced_search(self, auth_token, search_string):
+    # ,  property_list=["CollectionCode", "StructuredFormula"]):
+        params = (
+            ('query', search_string),
+            ('content type', "EXPERIMENTAL_INORGANIC"),
+        )
+
+        headers = {
+            'accept': 'application/xml',
+            'ICSD-Auth-Token': auth_token,
+        }
+
+        response = requests.get('https://icsd.fiz-karlsruhe.de/ws/search/expert', 
+                                headers=headers, 
+                                params=params,
+                                timeout=self.timeout)
+
+        # TODO add exception handling for timeouts 
+
+        self.session_history.append({search_string: response})
+
+        soup = BeautifulSoup(response.content, features="xml")
+        search_results = soup.idnums.contents[0].split(" ")
+        return search_results
+        # search_results = [x for x in str(response.content).split("idnums")[1].split(" ")[1:-2]]
+
+        # properties = self.fetch_data(search_results, property_list=property_list)
+        
+        # return list(zip(search_results, properties))
+
+    def fetch_data(self, auth_token, ids, property_list=["CollectionCode", "StructuredFormula"]):
+        """
+        Available properties: CollectionCode, HMS, StructuredFormula, StructureType, 
+        Title, Authors, Reference, CellParameter, ReducedCellParameter, StandardizedCellParameter, 
+        CellVolume, FormulaUnitsPerCell, FormulaWeight, Temperature, Pressure, RValue, 
+        SumFormula, ANXFormula, ABFormula, ChemicalName, MineralName, MineralGroup, 
+        CalculatedDensity, MeasuredDensity, PearsonSymbol, WyckoffSequence, Journal, 
+        Volume, PublicationYear, Page, Quality
+        """
+        if len(ids) > 500:
+            chunked_ids = np.array_split(ids, np.ceil(len(ids)/500))
+
+            return_responses = []
+            for i, chunk in enumerate(chunked_ids):
+                return_responses.append(self.fetch_data(chunk, 
+                                                        property_list=property_list))
+                
+                if i % 2 == 0:
+                    self.logout(auth_token, verbose=False)
+                    self.authorize(verbose=False) # TODO fails
+
+            flattened = [item for sublist in return_responses for item in sublist]
+
+            return flattened
+
+        headers = {
+            'accept': 'application/csv',
+            'ICSD-Auth-Token': auth_token,
+        }
+
+        params = (
+            ('idnum', ids),
+            ('windowsclient', self.windows_client),
+            ('listSelection', property_list),
+        )
+
+        response = requests.get('https://icsd.fiz-karlsruhe.de/ws/csv', headers=headers, params=params)
+
+        data = str(response.content).split("\\t\\n")[1:-1]
+
+        # If there's only a single response
+        if len(data) == 0 and len(ids) != 0:
+            data = str(response.content).split("\\t\\r\\n")[1:-1]
+
+        if len(property_list) > 1:
+            data = [x.split("\\t") for x in data]
+
+        self.session_history.append({str(ids): data})
+
+        return data
+
+    def fetch_cif(self, auth_token, id):
+        if auth_token is None:
+            print("You are not authenticated, call client.authorize() first")
+            return 
+
+        headers = {
+            'accept': 'application/cif',
+            'ICSD-Auth-Token': auth_token,
+        }
+
+        params = (
+            ('celltype', 'experimental'),
+            ('windowsclient', self.windows_client),
+        )
+        
+        response = requests.get(f'https://icsd.fiz-karlsruhe.de/ws/cif/{id}', headers=headers, params=params)
+        
+        self.session_history.append({id: response})
+
+        return response.content.decode("UTF-8").strip()
+
+    def fetch_cifs(self, auth_token, ids):
+        if auth_token is None:
+            print("You are not authenticated, call client.authorize() first")
+            return 
+
+        if isinstance(ids[0], tuple):
+            ids = [x[0] for x in ids]
+
+        headers = {
+            'accept': 'application/cif',
+            'ICSD-Auth-Token': auth_token,
+        }
+
+        params = (
+            ('idnum', ids),
+            ('celltype', 'experimental'),
+            ('windowsclient', self.windows_client),
+            ('filetype', 'cif'),
+        )
+
+        response = requests.get('https://icsd.fiz-karlsruhe.de/ws/cif/multiple', headers=headers, params=params)
+        if response.status_code == self.STATUS_OK:
+            cifs = response.content.decode("UTF-8").split('#(C)')[1:]
+            return ['#(C)'+cif for cif in cifs]
+        else:
+            raise Exception('Failed to get cifs.')    
+
+    # TODO move out
+    def fetch_all_cifs(self, auth_token, cif_path="./cifs/"):
+        for x in range(0, 1000000, 500):
+            self.logout(auth_token, verbose=False)
+            self.authorize(verbose=False) 
+
+            print(f"{x}-{x+499}")
+            search_res = self.advanced_search(auth_token, {"collectioncode": f"{x}-{x+499}"})
+
+            cifs = self.fetch_cifs(auth_token, search_res)
+
+            try:
+                print(cifs[0])
+                print(cifs[-1])
+            except:
+                print("\n\nNO CIFS RETURNED, LAST RESPONSE:\n")
+                print(self.session_history[-1].content)
+                
+            self.writeout(cifs, cif_path)
+
 
 if __name__ == "__main__":
     main()

--- a/ICSDClient.py
+++ b/ICSDClient.py
@@ -180,7 +180,7 @@ class ICSDClient():
 
         self.session_history.append({search_string: response})
 
-        soup = BeautifulSoup(response.content, "html.parser")
+        soup = BeautifulSoup(response.content, features="xml")
         search_results = soup.idnums.contents[0].split(" ")
         # search_results = [x for x in str(response.content).split("idnums")[1].split(" ")[1:-2]]
 


### PR DESCRIPTION
Hi Cameron, 

when I was querying ICSD I wanted to speed it up a bit and also to generate a zip file of the downloaded cifs and this escalated into quite a lot of changes.  

- separating the logic of making a query to the ICSD and managing the overall query (i.e. the difference between I want to get 3000 cifs and needing to make multiple calls within the cif limit). 
- context manager for login / logout
- collect cifs into zip file
- multithreaded calls to ICSD
- managing the multiple logins required for the separate calls
- allowing generic search strings to be passed in rather than dict of search_term: value because one of the queries I wanted to make couldn't be naturally expressed using only 'and' or 'or'. Using a dict of search terms to create the search string is still there but as a separate method now. 

I have tried to maintain the existing functionality where possible but the interface has changed a bit. What do you think? 

Jude